### PR TITLE
feat: use ms-vscode.live-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "extensionDependencies": [
         "HookyQR.JSDocTagComplete",
-        "auchenberg.vscode-browser-preview",
+        "ms-vscode.live-server",
         "christian-kohler.npm-intellisense",
         "DavidAnson.vscode-markdownlint",
         "dbaeumer.vscode-eslint",


### PR DESCRIPTION
Replace `auchenberg.vscode-browser-preview` with `ms-vscode.live-server`

`auchenberg.vscode-browser-preview` is now deprecated.